### PR TITLE
runner and java-version inputs for maven-verify

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -9,8 +9,8 @@ on:
       # calling workflow can specify inputs as follows:
       #     uses: <this reusable workflow>
       #     with:
-      #       mvn_options: <custom options>
-      mvn_options:
+      #       mvn-options: <custom options>
+      mvn-options:
         description: 'extra maven command line options (space separated)'
         default: ''
         required: false
@@ -43,6 +43,7 @@ jobs:
           cache: maven
 
       # test and verify
+      # (note that e.g. `mvn verify` runs all lifecycle phases up to and including the verify phase)
       # https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html
-      - name: Run maven verify (skip GPG signing)
-        run: mvn --batch-mode --update-snapshots --fail-fast -Dgpg.skip ${{ inputs.mvn_options }} verify
+      - name: Run maven verify
+        run: mvn --batch-mode --update-snapshots --fail-fast ${{ inputs.mvn-options }} verify

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -15,24 +15,30 @@ on:
         default: ''
         required: false
         type: string
+      runner:
+        # https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+        description: 'label of the hosted runner'
+        default: 'ubuntu-latest'
+        required: false
+        type: string
+      java-version:
+        description: 'java version for use with the setup-java action'
+        default: 21
+        required: false
+        type: number
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        # temurin LTS versions
-        version: [17, 21]
+    runs-on: ${{ inputs.runner }}
 
     steps:
       - uses: actions/checkout@v4
 
-      # setup
+      # https://github.com/actions/setup-java
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: ${{ matrix.version }}
+          java-version: ${{ inputs.java-version }}
           distribution: 'temurin'
           cache: maven
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ jobs:
   test:
     uses: FAIRDataTeam/github-workflows/.github/workflows/maven-verify.yml@v1
     with:
-      mvn_options: tidy:check com.github.spotbugs:spotbugs-maven-plugin:check
+      mvn_options:  -Dgpg.skip tidy:check com.github.spotbugs:spotbugs-maven-plugin:check
 ```
 
 ### docker-publish


### PR DESCRIPTION
Added `runner` and `java-version` inputs to maven-verify workflow, so the caller can define the strategy to be used.

Backward incompatible changes:

- renamed the `mvn_options` input (for consistency) 
- removed the `-Dgpg.skip` option from the mvn command (pass it in via `mvn-options` instead)

>[!IMPORTANT]
>Major version bump required.

fixes #5 