### PR TITLE
add repo-dispatch action with test

### DIFF
--- a/.github/actions/repo-dispatch/action.yml
+++ b/.github/actions/repo-dispatch/action.yml
@@ -10,16 +10,13 @@ inputs:
 runs:
   using: composite
   steps:
-#    - # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#masking-a-value-in-a-log
-#      name: mask secret token
-#      run: echo "::add-mask::$SECRET_TOKEN"
-#      shell: bash
-#      env:
-#        SECRET_TOKEN: ${{ inputs.secret-token }}
-#
-#    - name: mask secret token
-#      run: echo "::add-mask::${{ inputs.secret-token2 }}"
-#      shell: bash
+    - # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#masking-a-value-in-a-log
+      name: mask secret inputs
+      run: |
+        echo "::add-mask::${{ inputs.secret-token }}"
+        echo "::add-mask::${{ inputs.another-secret }}"
+      shell: bash
 
-    - shell: bash
+    - name: test secrets masking
       run: echo "${{ inputs.secret-token }} and ${{ inputs.another-secret }}"
+      shell: bash

--- a/.github/actions/repo-dispatch/action.yml
+++ b/.github/actions/repo-dispatch/action.yml
@@ -4,9 +4,26 @@ inputs:
   secret-token:
     description: fine-grained personal access token with content write permission for the target repo
     required: true
-  another-secret:
-    description: another secret
+    type: string
+  target-repo-owner:
+    description: target repository owner (as in <repo-owner>/<repo-name>)
     required: true
+    type: string
+  target-repo-name:
+    description: target repository name (as in <repo-owner>/<repo-name>)
+    required: true
+    type: string
+  event-type:
+    # https://docs.github.com/en/webhooks/webhook-events-and-payloads#repository_dispatch
+    description: action in repository_dispatch event
+    required: true
+    type: string
+  client-payload:
+    description: client_payload in repository_dispatch event (a JSON object)
+    required: true
+    type: string
+    default: '{}'
+
 runs:
   using: composite
   steps:
@@ -16,7 +33,16 @@ runs:
         echo "::add-mask::${{ inputs.secret-token }}"
         echo "::add-mask::${{ inputs.another-secret }}"
       shell: bash
-
-    - name: test secrets masking
-      run: echo "${{ inputs.secret-token }} and ${{ inputs.another-secret }}"
+    - name: post to github api dispatches endpoint
+      # https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#create-a-repository-dispatch-event
+      # https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication
+      run: |
+        curl --location \
+        --fail-with-body \
+        --request POST \
+        --header "Accept: application/vnd.github+json" \
+        --header "Authorization: Bearer ${{ inputs.secret-token }}" \
+        --header "X-GitHub-Api-Version: 2022-11-28" \
+        https://api.github.com/repos/${{ inputs.target-repo-owner }}/${{ inputs.target-repo-name }}/dispatches \
+        --data '{"event_type":"${{ inputs.event-type }}","client_payload":${{ inputs.client-payload }}}'
       shell: bash

--- a/.github/actions/repo-dispatch/action.yml
+++ b/.github/actions/repo-dispatch/action.yml
@@ -1,7 +1,7 @@
 name: repository-dispatch
 description: creates repository_dispatch event in target repository
 inputs:
-  secret-token:
+  secret-token:  # beware: mask is applied below
     description: fine-grained personal access token with content write permission for the target repo
     required: true
     type: string
@@ -28,10 +28,8 @@ runs:
   using: composite
   steps:
     - # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#masking-a-value-in-a-log
-      name: mask secret inputs
-      run: |
-        echo "::add-mask::${{ inputs.secret-token }}"
-        echo "::add-mask::${{ inputs.another-secret }}"
+      name: mask secret token
+      run: echo "::add-mask::${{ inputs.secret-token }}"
       shell: bash
     - name: post to github api dispatches endpoint
       # https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#create-a-repository-dispatch-event

--- a/.github/actions/repo-dispatch/action.yml
+++ b/.github/actions/repo-dispatch/action.yml
@@ -1,0 +1,27 @@
+name: repository-dispatch
+description: creates repository_dispatch event in target repository
+inputs:
+  secret-token:
+    description: fine-grained personal access token with content write permission for the target repo
+    required: true
+  secret-token-2:
+    description: another secret
+    required: true
+runs:
+  using: composite
+  steps:
+    - # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#masking-a-value-in-a-log
+      name: mask secret token
+      run: echo "::add-mask::$SECRET_TOKEN"
+      shell: bash
+      env:
+        SECRET_TOKEN: ${{ inputs.secret-token }}
+
+    - name: mask secret token
+      run: echo "::add-mask::${{ inputs.secret-token2 }}"
+      shell: bash
+
+    - shell: bash
+      run: |
+        echo "${{ inputs.secret-token }}"
+        echo "${{ inputs.secret-token-2 }}"

--- a/.github/actions/repo-dispatch/action.yml
+++ b/.github/actions/repo-dispatch/action.yml
@@ -15,11 +15,11 @@ inputs:
     type: string
   event-type:
     # https://docs.github.com/en/webhooks/webhook-events-and-payloads#repository_dispatch
-    description: action in repository_dispatch event
+    description: action in repository_dispatch event (as in github.event.action)
     required: true
     type: string
   client-payload:
-    description: client_payload in repository_dispatch event (a JSON object)
+    description: client_payload in repository_dispatch event (a JSON object, as in github.event.client_payload)
     required: true
     type: string
     default: '{}'

--- a/.github/actions/repo-dispatch/action.yml
+++ b/.github/actions/repo-dispatch/action.yml
@@ -4,24 +4,22 @@ inputs:
   secret-token:
     description: fine-grained personal access token with content write permission for the target repo
     required: true
-  secret-token-2:
+  another-secret:
     description: another secret
     required: true
 runs:
   using: composite
   steps:
-    - # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#masking-a-value-in-a-log
-      name: mask secret token
-      run: echo "::add-mask::$SECRET_TOKEN"
-      shell: bash
-      env:
-        SECRET_TOKEN: ${{ inputs.secret-token }}
-
-    - name: mask secret token
-      run: echo "::add-mask::${{ inputs.secret-token2 }}"
-      shell: bash
+#    - # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#masking-a-value-in-a-log
+#      name: mask secret token
+#      run: echo "::add-mask::$SECRET_TOKEN"
+#      shell: bash
+#      env:
+#        SECRET_TOKEN: ${{ inputs.secret-token }}
+#
+#    - name: mask secret token
+#      run: echo "::add-mask::${{ inputs.secret-token2 }}"
+#      shell: bash
 
     - shell: bash
-      run: |
-        echo "${{ inputs.secret-token }}"
-        echo "${{ inputs.secret-token-2 }}"
+      run: echo "${{ inputs.secret-token }} and ${{ inputs.another-secret }}"

--- a/.github/actions/repo-dispatch/action.yml
+++ b/.github/actions/repo-dispatch/action.yml
@@ -32,7 +32,7 @@ runs:
       run: echo "::add-mask::${{ inputs.secret-token }}"
       shell: bash
     - name: post to github api dispatches endpoint
-      # https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#create-a-repository-dispatch-event
+      # https://docs.github.com/en/rest/repos/repos?apiVersion=2026-03-10#create-a-repository-dispatch-event
       # https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication
       run: |
         curl --location \
@@ -40,7 +40,7 @@ runs:
         --request POST \
         --header "Accept: application/vnd.github+json" \
         --header "Authorization: Bearer ${{ inputs.secret-token }}" \
-        --header "X-GitHub-Api-Version: 2022-11-28" \
+        --header "X-GitHub-Api-Version: 2026-03-10" \
         https://api.github.com/repos/${{ inputs.target-repo-owner }}/${{ inputs.target-repo-name }}/dispatches \
         --data '{"event_type":"${{ inputs.event-type }}","client_payload":${{ inputs.client-payload }}}'
       shell: bash

--- a/.github/actions/repo-dispatch/action.yml
+++ b/.github/actions/repo-dispatch/action.yml
@@ -36,6 +36,7 @@ runs:
       # https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication
       run: |
         curl --location \
+        --verbose \
         --fail-with-body \
         --request POST \
         --header "Accept: application/vnd.github+json" \

--- a/.github/actions/repo-dispatch/action.yml
+++ b/.github/actions/repo-dispatch/action.yml
@@ -15,7 +15,7 @@ inputs:
     type: string
   event-type:
     # https://docs.github.com/en/webhooks/webhook-events-and-payloads#repository_dispatch
-    description: action in repository_dispatch event (as in github.event.action)
+    description: custom event type string (e.g. for filtering in on.repository_dispatch.types)
     required: true
     type: string
   client-payload:

--- a/.github/workflows/test-repo-dispatch-listener.yml
+++ b/.github/workflows/test-repo-dispatch-listener.yml
@@ -1,0 +1,12 @@
+name: test the receiving end of the repo-dispatch action
+
+on:
+  repository_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: | 
+          echo "action: ${{ github.event.action }}"
+          echo "payload: ${{ github.event.client_payload }}"

--- a/.github/workflows/test-repo-dispatch-listener.yml
+++ b/.github/workflows/test-repo-dispatch-listener.yml
@@ -9,4 +9,4 @@ jobs:
     steps:
       - run: | 
           echo "action: ${{ github.event.action }}"
-          echo "payload: ${{ github.event.client_payload }}"
+          echo "payload: ${{ github.event.client_payload.my-key }}"

--- a/.github/workflows/test-repo-dispatch-listener.yml
+++ b/.github/workflows/test-repo-dispatch-listener.yml
@@ -2,6 +2,7 @@ name: test the receiving end of the repo-dispatch action
 
 on:
   repository_dispatch:
+    types: [my-custom-event-type]
 
 jobs:
   test:

--- a/.github/workflows/test-repo-dispatch.yml
+++ b/.github/workflows/test-repo-dispatch.yml
@@ -1,0 +1,22 @@
+# This workflow tests the reusable repo-dispatch action
+
+name: test repo-dispatch action
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout so we can use local action
+        uses: actions/checkout@v4
+      - name: test action
+        uses: ./.github/actions/repo-dispatch
+        with:
+          secret-token: my-secret-token
+          secret-token-2: my-secret-token-2

--- a/.github/workflows/test-repo-dispatch.yml
+++ b/.github/workflows/test-repo-dispatch.yml
@@ -13,10 +13,13 @@ jobs:
   dispatch:
     runs-on: ubuntu-latest
     steps:
-      - name: checkout so we can use local action
+      - name: checkout in order to use local action
         uses: actions/checkout@v4
       - name: test action
         uses: ./.github/actions/repo-dispatch
         with:
           secret-token: my-secret-token
-          another-secret: my-other-secret
+          target-repo-name: ${{ github.event.repository.name }}
+          target-repo-owner: ${{ github.repository_owner }}
+          event-type: my-event
+          client-payload: '{"my-key": "my-value"}'

--- a/.github/workflows/test-repo-dispatch.yml
+++ b/.github/workflows/test-repo-dispatch.yml
@@ -19,4 +19,4 @@ jobs:
         uses: ./.github/actions/repo-dispatch
         with:
           secret-token: my-secret-token
-          secret-token-2: my-secret-token-2
+          another-secret: my-other-secret

--- a/.github/workflows/test-repo-dispatch.yml
+++ b/.github/workflows/test-repo-dispatch.yml
@@ -18,7 +18,7 @@ jobs:
       - name: test action
         uses: ./.github/actions/repo-dispatch
         with:
-          secret-token: my-secret-token
+          secret-token: ${{ secrets.personal_access_token }}
           target-repo-name: ${{ github.event.repository.name }}
           target-repo-owner: ${{ github.repository_owner }}
           event-type: my-event

--- a/.github/workflows/test-repo-dispatch.yml
+++ b/.github/workflows/test-repo-dispatch.yml
@@ -22,4 +22,7 @@ jobs:
           target-repo-name: ${{ github.event.repository.name }}
           target-repo-owner: ${{ github.repository_owner }}
           event-type: my-custom-event-type
-          client-payload: '{"my-key": "my-value"}'
+          client-payload: |
+            {
+              "my-key": "my-value"
+            }

--- a/.github/workflows/test-repo-dispatch.yml
+++ b/.github/workflows/test-repo-dispatch.yml
@@ -21,5 +21,5 @@ jobs:
           secret-token: ${{ secrets.personal_access_token }}
           target-repo-name: ${{ github.event.repository.name }}
           target-repo-owner: ${{ github.repository_owner }}
-          event-type: my-event
+          event-type: my-custom-event-type
           client-payload: '{"my-key": "my-value"}'

--- a/.github/workflows/test-repo-dispatch.yml
+++ b/.github/workflows/test-repo-dispatch.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: checkout in order to use local action
         uses: actions/checkout@v7
-      - name: test action
+      - name: test the repo-dispatch action (and usage example)
         uses: ./.github/actions/repo-dispatch
         with:
           secret-token: ${{ secrets.personal_access_token }}

--- a/.github/workflows/test-repo-dispatch.yml
+++ b/.github/workflows/test-repo-dispatch.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout in order to use local action
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: test action
         uses: ./.github/actions/repo-dispatch
         with:


### PR DESCRIPTION
Added a `repo-dispatch` action that triggers a `repository_dispatch` event in another repository via the github API.

This requires a personal access token with "Contents" write permission for the target repository, in the `secret-token` variable.

See [api docs].

Usage example:

```yaml
jobs:
  e2e:
    needs: publish
    runs-on: ubuntu-latest
    steps:
      - name: trigger e2e tests
        uses: FAIRDataTeam/github-workflows/.github/actions/repo-dispatch@v3
        with:
          secret-token: ${{ secrets.MY_REPO_DISPATCH_TOKEN }}
          target-repo-name: FAIRDataPoint-E2E-Tests
          target-repo-owner: FAIRDataTeam
          event-type: trigger-tests
          client-payload: |
            {
                "fdp_version": "${{ github.ref_name }}",
                "fdp_client_version": "latest"
            }
```

fixes #14 

[api docs]: https://docs.github.com/en/rest/repos/repos?apiVersion=2026-03-10#create-a-repository-dispatch-event