### PR TITLE
Conditional login to Docker Hub

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -64,6 +64,7 @@ jobs:
 
       - # https://github.com/docker/login-action
         name: Log in to Docker Hub
+        if: inputs.push == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKER_HUB_USERNAME }}


### PR DESCRIPTION
Only log in to docker hub if actually necessary, i.e. when we're going to push.

fixes #18 