### PR TITLE
Fix condition for docker hub login step

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -64,7 +64,7 @@ jobs:
 
       - # https://github.com/docker/login-action
         name: Log in to Docker Hub
-        if: inputs.push == 'true'
+        if: inputs.push
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKER_HUB_USERNAME }}


### PR DESCRIPTION
apparently the boolean string issue with action inputs (github-actions#1483) has been fixed, so we should now do an actual boolean test instead of string comparison

fixes #18