### PR TITLE
fix mongo-setup in maven-verify

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -49,7 +49,7 @@ on:
         required: false
         type: number
       db-version:
-        default: 5
+        default: 8
         required: false
         type: number
 

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Check MongoDB
         if: inputs.db-type == 'mongodb'
         run: |
-          mongo --eval "db.version()"
+          ${{ inputs.db-version < 6 && 'mongo' || 'mongosh' }} --eval "db.version()"
 
       - # https://github.com/actions/setup-java
         name: Setup Java

--- a/.github/workflows/test-maven-verify.yml
+++ b/.github/workflows/test-maven-verify.yml
@@ -1,0 +1,42 @@
+name: test-maven-verify.yml
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        java:
+          - 17
+          - 21
+        db:
+          - type: mongodb
+            name: ''  # not used for mongo
+            username: ''  # not used for mongo
+            password: ''  # not used for mongo
+            port: 0  # not used for mongo
+            version: 8
+          - type: postgresql
+            name: 'test'
+            username: 'test'
+            password: 'test'
+            port: 5432
+            version: 0  # not used for postgres
+    uses: ./.github/workflows/maven-verify.yml
+    with:
+      runner: ubuntu-24.04
+      java-version: ${{ matrix.java }}
+      db-type: ${{ matrix.db.type }}
+      db-name: ${{ matrix.db.name }}
+      db-username: ${{ matrix.db.username }}
+      db-password: ${{ matrix.db.password }}
+      db-port: ${{ matrix.db.port }}
+      db-version: ${{ matrix.db.version }}

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,8 @@
+<!-- This is a minimal pom file, just for testing purposes. -->
+<!-- https://maven.apache.org/guides/introduction/introduction-to-the-pom.html#Minimal_POM -->
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.fairdatateam.test</groupId>
+    <artifactId>test-maven-verify-workflow</artifactId>
+    <version>1</version>
+</project>


### PR DESCRIPTION
- changed default mongo `db-version` from `5` to `8` (fixes #22)
- uses shell command `mongo` vs `mongosh` depending mongo version (fixes #23)
- added test-maven-verify file to test these changes