### PR TITLE
Add build-args input for docker-publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,6 +20,11 @@ on:
         description: 'Determines if the resulting Docker image is pushed to Docker Hub'
         required: true
         type: boolean
+      build-args:
+        description: 'List of Docker build arguments (--build-arg), formatted as JSON array'
+        required: false
+        default: "[]"  # e.g. "['PROJECT_VERSION=1.2.3', '...']"
+        type: string
       context:
         description: 'Docker build context'
         required: false
@@ -85,6 +90,8 @@ jobs:
         name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
+          # https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#fromjson
+          build-args: ${{ fromJSON(inputs.build-args) }}
           context: ${{ inputs.context }}
           # https://docs.docker.com/build/concepts/dockerfile/#filename
           file: ${{ inputs.file }}

--- a/.github/workflows/test-docker-publish.yml
+++ b/.github/workflows/test-docker-publish.yml
@@ -15,4 +15,5 @@ jobs:
     uses: ./.github/workflows/docker-publish.yml
     secrets: inherit
     with:
+      build-args: "['PROJECT_VERSION=2.3.4']"
       push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
Add support for docker [build variables] via the `build-push-action`'s [build-args] input.

[build-args]: https://github.com/docker/build-push-action?tab=readme-ov-file#inputs

[build variables]: https://docs.docker.com/build/building/variables/